### PR TITLE
Fix wrong board defines

### DIFF
--- a/boards/nanorp2040connect.json
+++ b/boards/nanorp2040connect.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "arduino",
     "cpu": "cortex-m0plus",
-    "extra_flags": "-D NANO_RP2040_CONNECT -DARDUINO_ARCH_RP2040",
+    "extra_flags": "-D ARDUINO_NANO_RP2040_CONNECT -DARDUINO_ARCH_RP2040",
     "f_cpu": "133000000L",
     "hwids": [
       [

--- a/boards/pico.json
+++ b/boards/pico.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "arduino",
     "cpu": "cortex-m0plus",
-    "extra_flags": "-D RASPBERRY_PI_PICO -DARDUINO_ARCH_RP2040",
+    "extra_flags": "-D ARDUINO_RASPBERRY_PI_PICO -DARDUINO_ARCH_RP2040",
     "f_cpu": "133000000L",
     "hwids": [
       [


### PR DESCRIPTION
As one can see in 

https://github.com/arduino/ArduinoCore-mbed/blob/93e56ff002acec05d4a05b74047a9fab2e203938/platform.txt#L77

for each board, the macro 

```
-DARDUINO_{build.board}
```
is defined.  For

https://github.com/arduino/ArduinoCore-mbed/blob/93e56ff002acec05d4a05b74047a9fab2e203938/boards.txt#L204

this means 

```
-DARDUINO_NANO_RP2040_CONNECT
```

will be defined. However, the previous board definitions fail to add that `ARDUINO_` prefix to the defines. 

https://github.com/platformio/platform-raspberrypi/blob/095da74655dc4cc3cd8e32e6517288c4b8466fb5/boards/nanorp2040connect.json#L5-L5

This ends up not triggering / enabling code in libraries that depend on this, as can e.g. be seen in 

https://github.com/arduino-libraries/WiFiNINA/blob/5d63d7de818e5c584279d6e5945a103d3ca108c5/src/utility/nano_rp2040_support.cpp#L20

where `ARDUINO_NANO_RP2040_CONNECT` is checked, but PIO only defines `NANO_RP2040_CONNECT`, thus leading to compile errors as e.g. seen in [this community topic](https://community.platformio.org/t/arduino-nano-rp2040-connect-blinking-rgb-led-does-not-compile/21782)

This PR fixes both board definitions in the platform.