### PR TITLE
Use *.elf instead of *.bin if no offset given

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -222,6 +222,8 @@ elif upload_protocol in debug_tools:
         UPLOADER="openocd",
         UPLOADERFLAGS=openocd_args,
         UPLOADCMD="$UPLOADER $UPLOADERFLAGS")
+    if not board.get("upload").get("offset_address"):
+        upload_source = target_elf
     upload_actions = [env.VerboseAction("$UPLOADCMD", "Uploading $SOURCE")]
 
 # custom upload tool


### PR DESCRIPTION
Currently `*.bin` is always selected for upload. However, uploading the bin-file requires option `offset_address` to be specified. This PR is [inspired by platform-ststm32](https://github.com/platformio/platform-ststm32/blob/develop/builder/main.py#L327-L328) and chooses `*.elf` in favor of `*.bin` if no `offset_address` is configured.