### PR TITLE
Add upload_target option

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -210,6 +210,9 @@ elif upload_protocol in debug_tools:
             ["-c", "adapter speed %s" % env.GetProjectOption("debug_speed")]
         )
     openocd_args.extend([
+        "-c", "targets %s" % env.GetProjectOption("upload_target", "rp2040.core0")
+    ])
+    openocd_args.extend([
         "-c", "program {$SOURCE} %s verify reset; shutdown;" %
         board.get("upload.offset_address", "")
     ])


### PR DESCRIPTION
Successful upload via openocd requires a core to be selected. [Most recent raspberrypi-openocd has a default selection of core 0 builtin](https://github.com/raspberrypi/openocd/commit/f8e14ec97b0d98c8e2ffdd08ab5ff9537f1c9a63), but [the version currently deployed by platformio](https://github.com/platformio/platform-raspberrypi/blob/develop/platform.json#L49) is missing this preselection. Hence the selection must be made externally.

This PR introduces an option `upload_target` to select the target via `platform.ini`. Additionally, the default value of recent openocd builds (`rp2040.core0`) is replicated as default value.

Without targets being selected, flash programming will fail with an error similiar to `Warn : no flash bank found for address 0x...` .