### PR TITLE
Fix nanorp2040connect flash size to be full 16mb

### DIFF
--- a/boards/nanorp2040connect.json
+++ b/boards/nanorp2040connect.json
@@ -28,7 +28,7 @@
   "name": "Arduino Nano RP2040 Connect",
   "upload": {
     "maximum_ram_size": 270336,
-    "maximum_size": 2097152,
+    "maximum_size": 16777216,
     "require_upload_port": true,
     "native_usb": true,
     "use_1200bps_touch": true,


### PR DESCRIPTION
The nanorp2040connect from Arduino has 16mb of flash size not 2mb.
See: https://docs.arduino.cc/hardware/nano-rp2040-connect

Compiling from the arduino IDE also shows:
```
Sketch uses 98233 bytes (0%) of program storage space. Maximum is 16777216 bytes.
```